### PR TITLE
[FEATURE] Add support for iNavigateTo

### DIFF
--- a/src/steps/iNavigateTo.js
+++ b/src/steps/iNavigateTo.js
@@ -22,11 +22,7 @@ module.exports = {
         "$"                           //end of string
     ].join("")),
     icon: "locate-me",
-<<<<<<< HEAD
     action: function(sHash) {
-=======
-    action: function(sId, sHash) {
->>>>>>> 9e0760be2d0f43745ba90220b9acab4ed9d1753d
         var oWaitForOptions, that, oHasherChanger;
         that = this;
 
@@ -36,11 +32,7 @@ module.exports = {
 
         oWaitForOptions = {
             success: function() {
-<<<<<<< HEAD
                 that.Opa5.assert.strictEqual(oHasherChanger.getHash(), sHash, "Hash '" + sHash + "' set successfully.");
-=======
-                that.Opa5.assert.strictEquals(oHasherChanger.getHash(), sHash, "Hash '" + sHash + "' set successfully.");
->>>>>>> 9e0760be2d0f43745ba90220b9acab4ed9d1753d
             }
         };
         that.opa.waitFor(oWaitForOptions);

--- a/src/steps/iNavigateTo.js
+++ b/src/steps/iNavigateTo.js
@@ -1,0 +1,41 @@
+/**
+ * This step will set a new hash to the app.
+ * The app should react to the navigation by providing proper routing.
+ *
+ * ToDo: Add [with <JSON>] to synopsis to pass data as json
+ *    regex: "(\\s+with\\s+(.+?))?"
+ *    parsing: var oObject = JSON.parse(sObject);
+ */
+module.exports = {
+    docs: {
+        description: "Performs navigation using hash.",
+        synopsis: "I navigate to <hash>",
+        examples: [
+            "I navigate to /Customers/4711",
+            "I navigate to /Customers/4711?&tab=person"
+        ]
+    },
+    regexp: new RegExp([
+        "^",                          //start of string
+        "I\\snavigate\\sto\\s",       //enty point
+        "([=a-zA-Z0-9\/\?\&]+){1}",   //hash with parameters
+        "$"                           //end of string
+    ].join("")),
+    icon: "locate-me",
+    action: function(sId, sHash) {
+        var oWaitForOptions, that, oHasherChanger;
+        that = this;
+
+        oHasherChanger = sap.ui.test.Opa5.getHashChanger();
+
+        oHasherChanger.setHash(sHash);
+
+        oWaitForOptions = {
+            success: function() {
+                that.Opa5.assert.strictEquals(oHasherChanger.getHash(), sHash, "Hash '" + sHash + "' set successfully.");
+            }
+        };
+        that.opa.waitFor(oWaitForOptions);
+
+    }
+};

--- a/src/steps/iNavigateTo.js
+++ b/src/steps/iNavigateTo.js
@@ -1,0 +1,41 @@
+/**
+ * This step will set a new hash to the app.
+ * The app should react to the navigation by providing proper routing.
+ *
+ * ToDo: Add [with <JSON>] to synopsis to pass data as json
+ *    regex: "(\\s+with\\s+(.+?))?"
+ *    parsing: var oObject = JSON.parse(sObject);
+ */
+module.exports = {
+    docs: {
+        description: "Performs navigation using hash.",
+        synopsis: "I navigate to <hash>",
+        examples: [
+            "I navigate to /Customers/4711",
+            "I navigate to /Customers/4711?&tab=person"
+        ]
+    },
+    regexp: new RegExp([
+        "^",                          //start of string
+        "I\\snavigate\\sto\\s",       //enty point
+        "([=a-zA-Z0-9\/\?\&]+){1}",   //hash with parameters
+        "$"                           //end of string
+    ].join("")),
+    icon: "locate-me",
+    action: function(sHash) {
+        var oWaitForOptions, that, oHasherChanger;
+        that = this;
+
+        oHasherChanger = sap.ui.test.Opa5.getHashChanger();
+
+        oHasherChanger.setHash(sHash);
+
+        oWaitForOptions = {
+            success: function() {
+                that.Opa5.assert.strictEqual(oHasherChanger.getHash(), sHash, "Hash '" + sHash + "' set successfully.");
+            }
+        };
+        that.opa.waitFor(oWaitForOptions);
+
+    }
+};

--- a/src/steps/index.js
+++ b/src/steps/index.js
@@ -7,7 +7,8 @@ sap.ui.define([
     "./iPressBrowserBack",
     "./iStartTheApp",
     "./iClickOnNestedItem",
-    "./iCannotSee"
+    "./iCannotSee",
+    "./iNavigateTo"
 ], function () {
     return Array.prototype.slice.call(arguments, 0);
 });

--- a/test/ui5app/specs/Test.feature
+++ b/test/ui5app/specs/Test.feature
@@ -1,5 +1,5 @@
 Feature: Can trigger all actions provided by Gherkin Generic Steps
-  
+
   Background: Initial state
     Given  I start the app from 'ui5app/test/ui5app.html'
 
@@ -12,13 +12,13 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
     Given I can see verticalBox in Main view
      When I click on the control deeply nested inside verticalBox with text containing 'quar' in Main view
      Then I can see lblListItemClicked with text 'Square shape was clicked' in Main view
-  
+
   Scenario: iCanSee
     Then I can see btnClickMe in Main view
      And I can see btnClickMe with text containing 'button was clicked' in Main view
      And I can see btnClickMe with text starting with 'This button' in Main view
      And I can see btnClickMe with text ending with 'times' in Main view
-    
+
   Scenario: iCanSee (nested)
     Then I can see the first sap.ui.core.Item control deeply nested inside verticalBox in Main view
      And I can see the control directly nested inside verticalBox with text 'Hide list of shapes' in Main view
@@ -59,18 +59,25 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
      When I click on btnRemoveListItem in Main view 3 times
      Then lstShapes in Main view contains no items
 
+  Scenario: iNavigateTo changes Hash
+    Given I can see lblLocation in Main view
+    When I navigate to /Customer
+    Then I can see lblLocation with text ending with '/Customer' in Main view
+    When I navigate to /Customer/7?tab=profile
+    Then I can see lblLocation with text ending with '/Customer/7?tab=profile' in Main view
+
   Scenario: iPressBrowserBack pre-requisite
     Given I can see lblLocation in Main view
       And I can see btnNavigate in Main view
      When I click on btnNavigate in Main view
       And I click on btnRefreshLocation in Main view
-     Then I can see lblLocation with text ending with 'ui5app.html#nav' in Main view 
+     Then I can see lblLocation with text ending with 'ui5app.html#nav' in Main view
 
   Scenario: iPressBrowserBack pre-requisite
     Given I can see lblLocation in Main view
      When I click on btnNavigate in Main view
       And I press browser back
-     Then I can see lblLocation with text containing 'ui5app.html' in Main view 
+     Then I can see lblLocation with text containing 'ui5app.html' in Main view
 
   Scenario: iCannotSee (item does not exist - no main view given)
      Then I cannot see btnNotExisting
@@ -80,4 +87,3 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
      Then I cannot see lstShapes in Main view
   Scenario: iCannotSee (item does not exist)
      Then I cannot see notExistingButton in Main view
-

--- a/test/ui5app/specs/Test.feature
+++ b/test/ui5app/specs/Test.feature
@@ -61,8 +61,12 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
 
   Scenario: iNavigateTo changes Hash
     Given I can see lblLocation in Main view
-    When I navigate to /Customer
-    When I navigate to /Customer/7?tab=profile
+     When I navigate to /Customer
+      And I click on btnRefreshLocation in Main view
+     Then I can see lblLocation with text ending with '/Customer' in Main view
+     When I navigate to /Customer/7?tab=profile
+      And I click on btnRefreshLocation in Main view
+     Then I can see lblLocation with text ending with '/Customer/7?tab=profile' in Main view
 
   Scenario: iPressBrowserBack pre-requisite
     Given I can see lblLocation in Main view


### PR DESCRIPTION
This PR provides support for iNavigateTo step, that sets a new hash to the app under test to trigger navigation. Developers can create test scenarios for navigation and routing of their UI5 app.

PR contains test scenario "iNavigateTo changes Hash" to verify step behavior.