### PR TITLE
[FEATURE] Add support for iSetFocus and controlHasFocus steps

### DIFF
--- a/src/steps/controlHasFocus.js
+++ b/src/steps/controlHasFocus.js
@@ -1,0 +1,32 @@
+module.exports = {
+	docs: {
+		description: "Checks if a control has focus",
+		synopsis: "Control <controlId> has focus [in <viewName> view]",
+		examples: ["Control inputField has focus", "Control saveButton has focus in Creation view"]
+	},
+	icon: "edit",
+	regexp: new RegExp([
+    "^Control\\s", //start of string
+    "(.+?)", //<controlId>
+    "\\shas\\sfocus",
+    "(\\sin\\s([a-zA-Z0-9\\.]+)\\sview)?", // view part
+    "$" //end of string
+  ].join("")),
+	action: function(sControlId, sViewPart, sViewName) {
+		var that = this;
+		var oWaitForOptions = {
+			id: sControlId,
+			success: function(oControl) {
+
+        that.Opa5.assert.ok(true, "Control " + sControlId + " has been found in " + sViewName + " view");
+
+        that.Opa5.assert.ok(oControl.$().hasClass("sapMFocus"), "Control " + sControlId + " has focus (has class 'sapMFocus')");
+
+			}
+		};
+		if (sViewPart) {
+			oWaitForOptions.viewName = sViewName;
+		}
+		this.opa.waitFor(oWaitForOptions);
+	}
+};

--- a/src/steps/iNavigateTo.js
+++ b/src/steps/iNavigateTo.js
@@ -22,11 +22,7 @@ module.exports = {
         "$"                           //end of string
     ].join("")),
     icon: "locate-me",
-<<<<<<< HEAD
     action: function(sHash) {
-=======
-    action: function(sId, sHash) {
->>>>>>> 9e0760be2d0f43745ba90220b9acab4ed9d1753d
         var oWaitForOptions, that, oHasherChanger;
         that = this;
 
@@ -36,11 +32,7 @@ module.exports = {
 
         oWaitForOptions = {
             success: function() {
-<<<<<<< HEAD
                 that.Opa5.assert.strictEqual(oHasherChanger.getHash(), sHash, "Hash '" + sHash + "' set successfully.");
-=======
-                that.Opa5.assert.strictEquals(oHasherChanger.getHash(), sHash, "Hash '" + sHash + "' set successfully.");
->>>>>>> 9e0760be2d0f43745ba90220b9acab4ed9d1753d
             }
         };
         that.opa.waitFor(oWaitForOptions);

--- a/src/steps/iNavigateTo.js
+++ b/src/steps/iNavigateTo.js
@@ -1,0 +1,41 @@
+/**
+ * This step will set a new hash to the app.
+ * The app should react to the navigation by providing proper routing.
+ *
+ * ToDo: Add [with <JSON>] to synopsis to pass data as json
+ *    regex: "(\\s+with\\s+(.+?))?"
+ *    parsing: var oObject = JSON.parse(sObject);
+ */
+module.exports = {
+    docs: {
+        description: "Performs navigation using hash.",
+        synopsis: "I navigate to <hash>",
+        examples: [
+            "I navigate to /Customers/4711",
+            "I navigate to /Customers/4711?&tab=person"
+        ]
+    },
+    regexp: new RegExp([
+        "^",                          //start of string
+        "I\\snavigate\\sto\\s",       //enty point
+        "([=a-zA-Z0-9\/\?\&]+){1}",   //hash with parameters
+        "$"                           //end of string
+    ].join("")),
+    icon: "locate-me",
+    action: function(sId, sHash) {
+        var oWaitForOptions, that, oHasherChanger;
+        that = this;
+
+        oHasherChanger = sap.ui.test.Opa5.getHashChanger();
+
+        oHasherChanger.setHash(sHash);
+
+        oWaitForOptions = {
+            success: function() {
+                that.Opa5.assert.strictEquals(oHasherChanger.getHash(), sHash, "Hash '" + sHash + "' set successfully.");
+            }
+        };
+        that.opa.waitFor(oWaitForOptions);
+
+    }
+};

--- a/src/steps/iNavigateTo.js
+++ b/src/steps/iNavigateTo.js
@@ -1,0 +1,41 @@
+/**
+ * This step will set a new hash to the app.
+ * The app should react to the navigation by providing proper routing.
+ *
+ * ToDo: Add [with <JSON>] to synopsis to pass data as json
+ *    regex: "(\\s+with\\s+(.+?))?"
+ *    parsing: var oObject = JSON.parse(sObject);
+ */
+module.exports = {
+    docs: {
+        description: "Performs navigation using hash.",
+        synopsis: "I navigate to <hash>",
+        examples: [
+            "I navigate to /Customers/4711",
+            "I navigate to /Customers/4711?&tab=person"
+        ]
+    },
+    regexp: new RegExp([
+        "^",                          //start of string
+        "I\\snavigate\\sto\\s",       //enty point
+        "([=a-zA-Z0-9\/\?\&]+){1}",   //hash with parameters
+        "$"                           //end of string
+    ].join("")),
+    icon: "locate-me",
+    action: function(sHash) {
+        var oWaitForOptions, that, oHasherChanger;
+        that = this;
+
+        oHasherChanger = sap.ui.test.Opa5.getHashChanger();
+
+        oHasherChanger.setHash(sHash);
+
+        oWaitForOptions = {
+            success: function() {
+                that.Opa5.assert.strictEqual(oHasherChanger.getHash(), sHash, "Hash '" + sHash + "' set successfully.");
+            }
+        };
+        that.opa.waitFor(oWaitForOptions);
+
+    }
+};

--- a/src/steps/iPressKey.js
+++ b/src/steps/iPressKey.js
@@ -1,0 +1,51 @@
+module.exports = {
+	docs: {
+		description: "Fire a key press",
+		synopsis: "I press <key> [+<modifier>] at <control> [in <viewName> view]",
+		examples: ["I press ENTER at inputField", "I press 'F1' at inputField in Creation view", "I press ARROW_DOWN + ALT at myComboBox"]
+	},
+	icon: "edit",
+	regexp: /^I press (.+?)(\s\+\s(ALT|SHIFT|CTRL))?\sat\s([a-zA-Z0-9]+)(\sin\s([a-zA-Z0-9\.]+)\sview)?$/,
+	regexp: new RegExp([
+    "^I press\\s",    //start of string
+    "(.+?)",          //key
+    "(\\s\+\\s(ALT|SHIFT|CTRL))?",    //modifier
+    "\\sat ([a-zA-Z0-9]+)",           //control
+    "( in ([a-zA-Z0-9\.]+) view)?",   //view
+    "$"   //end of string
+  ].join("")),
+	action: function(sKey, sModifierPart, sModifier, sControlId, sViewPart, sViewName) {
+		var that = this;
+		var oWaitForOptions = {
+			id: sControlId,
+			success: function(oControl) {
+				var oUtils = sap.ui.test.Opa5.getUtils(),
+          bShiftKey = sModifier === "SHIFT" ? true : false,
+					bAltKey = sModifier === "ALT" ? true : false,
+					bCtrlKey = sModifier === "CTRL" ? true : false;
+
+				if (!jQuery.sap.KeyCodes[sKey]) {
+					that.Opa5.assert.ok(false, "Key" + sKey + " is not an enum of jQuery.sap.KeyCodes");
+				}
+
+				/**
+				 * Programmatically triggers a 'keydown' event on a specified target.
+				 * @see sap.ui.test.qunit.triggerKeyEvent
+				 *
+				 * @param {string | DOMElement} oTarget The ID of a DOM element or a DOM element which serves as target of the event
+				 * @param {string | int} sKey The keys name as defined in <code>jQuery.sap.KeyCodes</code> or its key code
+				 * @param {boolean} bShiftKey Indicates whether the shift key is down in addition
+				 * @param {boolean} bAltKey Indicates whether the alt key is down in addition
+				 * @param {boolean} bCtrlKey Indicates whether the ctrl key is down in addition
+				 * @public
+				 */
+				oUtils.triggerKeyboardEvent(oControl.getId(), sKey, bShiftKey, bAltKey, bCtrlKey);
+
+			}
+		};
+		if (sViewPart) {
+			oWaitForOptions.viewName = sViewName;
+		}
+		this.opa.waitFor(oWaitForOptions);
+	}
+};

--- a/src/steps/iSetFocus.js
+++ b/src/steps/iSetFocus.js
@@ -1,0 +1,31 @@
+module.exports = {
+	docs: {
+		description: "Set focus on a control",
+		synopsis: "I set focus on <controlId> [in <viewName> view]",
+		examples: ["I set focus on inputField", "I set focus on saveButton in Creation view"]
+	},
+	icon: "edit",
+	regexp: new RegExp([
+    "^I set focus on\\s", //start of string
+    "(.+?)", //<controlId>
+    "(\\sin\\s([a-zA-Z0-9\\.]+)\\sview)?", // view part
+    "$" //end of string
+  ].join("")),
+	action: function(sControlId, sViewPart, sViewName) {
+		var that = this;
+		var oWaitForOptions = {
+			id: sControlId,
+			success: function(oControl) {
+
+        that.Opa5.assert.ok(true, "Control " + sControlId + " has been found in " + sViewName + " view");
+
+				oControl.focus();
+
+			}
+		};
+		if (sViewPart) {
+			oWaitForOptions.viewName = sViewName;
+		}
+		this.opa.waitFor(oWaitForOptions);
+	}
+};

--- a/src/steps/index.js
+++ b/src/steps/index.js
@@ -7,6 +7,8 @@ sap.ui.define([
     "./iPressBrowserBack",
     "./iStartTheApp",
     "./iClickOnNestedItem",
+    "./iSetFocus",
+    "./controlHasFocus",
     "./iCannotSee"
 ], function () {
     return Array.prototype.slice.call(arguments, 0);

--- a/src/steps/index.js
+++ b/src/steps/index.js
@@ -7,6 +7,7 @@ sap.ui.define([
     "./iPressBrowserBack",
     "./iStartTheApp",
     "./iClickOnNestedItem",
+    "./iPressKey",
     "./iCannotSee"
 ], function () {
     return Array.prototype.slice.call(arguments, 0);

--- a/src/steps/index.js
+++ b/src/steps/index.js
@@ -7,7 +7,8 @@ sap.ui.define([
     "./iPressBrowserBack",
     "./iStartTheApp",
     "./iClickOnNestedItem",
-    "./iCannotSee"
+    "./iCannotSee",
+    "./iNavigateTo"
 ], function () {
     return Array.prototype.slice.call(arguments, 0);
 });

--- a/test/ui5app/specs/Test.feature
+++ b/test/ui5app/specs/Test.feature
@@ -1,5 +1,5 @@
 Feature: Can trigger all actions provided by Gherkin Generic Steps
-  
+
   Background: Initial state
     Given  I start the app from 'ui5app/test/ui5app.html'
 
@@ -12,13 +12,13 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
     Given I can see verticalBox in Main view
      When I click on the control deeply nested inside verticalBox with text containing 'quar' in Main view
      Then I can see lblListItemClicked with text 'Square shape was clicked' in Main view
-  
+
   Scenario: iCanSee
     Then I can see btnClickMe in Main view
      And I can see btnClickMe with text containing 'button was clicked' in Main view
      And I can see btnClickMe with text starting with 'This button' in Main view
      And I can see btnClickMe with text ending with 'times' in Main view
-    
+
   Scenario: iCanSee (nested)
     Then I can see the first sap.ui.core.Item control deeply nested inside verticalBox in Main view
      And I can see the control directly nested inside verticalBox with text 'Hide list of shapes' in Main view
@@ -59,18 +59,25 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
      When I click on btnRemoveListItem in Main view 3 times
      Then lstShapes in Main view contains no items
 
+  Scenario: iNavigateTo changes Hash
+    Given I can see lblLocation in Main view
+    When I navigate to /Customer
+    Then I can see lblLocation with text ending with '/Customer' in Main view
+    When I navigate to /Customer/7?tab=profile
+    Then I can see lblLocation with text ending with '/Customer/7?tab=profile' in Main view
+
   Scenario: iPressBrowserBack pre-requisite
     Given I can see lblLocation in Main view
       And I can see btnNavigate in Main view
      When I click on btnNavigate in Main view
       And I click on btnRefreshLocation in Main view
-     Then I can see lblLocation with text ending with 'ui5app.html#nav' in Main view 
+     Then I can see lblLocation with text ending with 'ui5app.html#nav' in Main view
 
   Scenario: iPressBrowserBack pre-requisite
     Given I can see lblLocation in Main view
      When I click on btnNavigate in Main view
       And I press browser back
-     Then I can see lblLocation with text containing 'ui5app.html' in Main view 
+     Then I can see lblLocation with text containing 'ui5app.html' in Main view
 
   Scenario: iCannotSee (item does not exist - no main view given)
      Then I cannot see btnNotExisting
@@ -80,4 +87,3 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
      Then I cannot see lstShapes in Main view
   Scenario: iCannotSee (item does not exist)
      Then I cannot see notExistingButton in Main view
-

--- a/test/ui5app/specs/Test.feature
+++ b/test/ui5app/specs/Test.feature
@@ -1,7 +1,16 @@
 Feature: Can trigger all actions provided by Gherkin Generic Steps
-  
+
   Background: Initial state
     Given  I start the app from 'ui5app/test/ui5app.html'
+
+  Scenario: iPressKey at control
+    Given I can see cbxSelection in Main view
+      And I can see lblComboboxSelection in Main view
+     When I press END at cbxSelection in Main view
+     Then I can see lblComboboxSelection with text 'black' in Main view
+     When I press ARROW_DOWN + ALT at cbxSelection in Main view
+     When I press ARROW_UP at cbxSelection in Main view
+     Then I can see lblComboboxSelection with text 'blue' in Main view
 
   Scenario: iClickOnNestedItem by position
     Given I can see verticalBox in Main view
@@ -12,13 +21,13 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
     Given I can see verticalBox in Main view
      When I click on the control deeply nested inside verticalBox with text containing 'quar' in Main view
      Then I can see lblListItemClicked with text 'Square shape was clicked' in Main view
-  
+
   Scenario: iCanSee
     Then I can see btnClickMe in Main view
      And I can see btnClickMe with text containing 'button was clicked' in Main view
      And I can see btnClickMe with text starting with 'This button' in Main view
      And I can see btnClickMe with text ending with 'times' in Main view
-    
+
   Scenario: iCanSee (nested)
     Then I can see the first sap.ui.core.Item control deeply nested inside verticalBox in Main view
      And I can see the control directly nested inside verticalBox with text 'Hide list of shapes' in Main view
@@ -64,13 +73,13 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
       And I can see btnNavigate in Main view
      When I click on btnNavigate in Main view
       And I click on btnRefreshLocation in Main view
-     Then I can see lblLocation with text ending with 'ui5app.html#nav' in Main view 
+     Then I can see lblLocation with text ending with 'ui5app.html#nav' in Main view
 
   Scenario: iPressBrowserBack pre-requisite
     Given I can see lblLocation in Main view
      When I click on btnNavigate in Main view
       And I press browser back
-     Then I can see lblLocation with text containing 'ui5app.html' in Main view 
+     Then I can see lblLocation with text containing 'ui5app.html' in Main view
 
   Scenario: iCannotSee (item does not exist - no main view given)
      Then I cannot see btnNotExisting
@@ -80,4 +89,3 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
      Then I cannot see lstShapes in Main view
   Scenario: iCannotSee (item does not exist)
      Then I cannot see notExistingButton in Main view
-

--- a/test/ui5app/specs/Test.feature
+++ b/test/ui5app/specs/Test.feature
@@ -61,8 +61,12 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
 
   Scenario: iNavigateTo changes Hash
     Given I can see lblLocation in Main view
-    When I navigate to /Customer
-    When I navigate to /Customer/7?tab=profile
+     When I navigate to /Customer
+      And I click on btnRefreshLocation in Main view
+     Then I can see lblLocation with text ending with '/Customer' in Main view
+     When I navigate to /Customer/7?tab=profile
+      And I click on btnRefreshLocation in Main view
+     Then I can see lblLocation with text ending with '/Customer/7?tab=profile' in Main view
 
   Scenario: iPressBrowserBack pre-requisite
     Given I can see lblLocation in Main view

--- a/test/ui5app/specs/Test.feature
+++ b/test/ui5app/specs/Test.feature
@@ -1,5 +1,5 @@
 Feature: Can trigger all actions provided by Gherkin Generic Steps
-  
+
   Background: Initial state
     Given  I start the app from 'ui5app/test/ui5app.html'
 
@@ -12,13 +12,13 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
     Given I can see verticalBox in Main view
      When I click on the control deeply nested inside verticalBox with text containing 'quar' in Main view
      Then I can see lblListItemClicked with text 'Square shape was clicked' in Main view
-  
+
   Scenario: iCanSee
     Then I can see btnClickMe in Main view
      And I can see btnClickMe with text containing 'button was clicked' in Main view
      And I can see btnClickMe with text starting with 'This button' in Main view
      And I can see btnClickMe with text ending with 'times' in Main view
-    
+
   Scenario: iCanSee (nested)
     Then I can see the first sap.ui.core.Item control deeply nested inside verticalBox in Main view
      And I can see the control directly nested inside verticalBox with text 'Hide list of shapes' in Main view
@@ -48,6 +48,11 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
      When I enter '00012345689ABC' into txtProductId in Main view
      Then I can see txtProductId with value '00012345689ABC' in Main view
 
+   Scenario: iSetFocus and controlHasFocus
+     Given I can see txtProductId in Main view
+      When I set focus on txtProductId in Main view
+      Then control txtProductId has focus in Main view
+
   Scenario: aggregationHasItem count existing items
     Given I can see lstShapes in Main view
      Then lstShapes in Main view contains 3 items
@@ -64,13 +69,13 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
       And I can see btnNavigate in Main view
      When I click on btnNavigate in Main view
       And I click on btnRefreshLocation in Main view
-     Then I can see lblLocation with text ending with 'ui5app.html#nav' in Main view 
+     Then I can see lblLocation with text ending with 'ui5app.html#nav' in Main view
 
   Scenario: iPressBrowserBack pre-requisite
     Given I can see lblLocation in Main view
      When I click on btnNavigate in Main view
       And I press browser back
-     Then I can see lblLocation with text containing 'ui5app.html' in Main view 
+     Then I can see lblLocation with text containing 'ui5app.html' in Main view
 
   Scenario: iCannotSee (item does not exist - no main view given)
      Then I cannot see btnNotExisting
@@ -80,4 +85,3 @@ Feature: Can trigger all actions provided by Gherkin Generic Steps
      Then I cannot see lstShapes in Main view
   Scenario: iCannotSee (item does not exist)
      Then I cannot see notExistingButton in Main view
-

--- a/test/ui5app/view/Main.view.xml
+++ b/test/ui5app/view/Main.view.xml
@@ -1,7 +1,7 @@
-<mvc:View 
+<mvc:View
     xmlns:mvc="sap.ui.core.mvc"
     xmlns:core="sap.ui.core"
-    xmlns="sap.m"            
+    xmlns="sap.m"
     controllerName="ui5app.controller">
 
     <Panel headerText="Gherkin Generic Actions test app">
@@ -19,11 +19,19 @@
                    <core:Item text="Circle" />
                </items>
            </SelectList>
+           <ComboBox id="cbxSelection" selectedKey="{/selectedComboboxKey}">
+             <items>
+                 <core:Item key="red" text="red" />
+                 <core:Item key="blue" text="blue" />
+                 <core:Item key="black" text="black" />
+             </items>
+           </ComboBox>
+           <Label id="lblComboboxSelection" text="{/selectedComboboxKey}"></Label>
            <Button id="btnRemoveListItem" text="Remove List Item" press="onRemoveListItemClicked" />
            <Label class="sapUiSmallMarginTop" visible="true" id="lblListItemClicked" text="{/sSelectedListItem} shape was clicked"></Label>
 
            <Input id="txtProductId" type="Text" placeholder="Enter Product ID" />
        </VBox>
-    </Panel>                                                     
+    </Panel>
 
  </mvc:View>


### PR DESCRIPTION
This PR provides support for tests to focus handling. 
- Step iSetFocus sets focus on a control.
- Step controlHasFocus checks if a control has focus (checks for class sapMFocus)

Restriction: only works with sap.m library. Maybe check focus with vanilla jQuery?

Test features included.